### PR TITLE
3rd party app submissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ SIDEKIQ_PASSWORD=changeme
 SESSION_SECRET=changeme
 
 VIEWER_SINATRA_REPO=everypolitician/viewer-sinatra
+EVERYPOLITICIAN_DATA_REPO=everypolitican/everypolitician-data

--- a/Rakefile
+++ b/Rakefile
@@ -29,4 +29,4 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task default: [:rubocop, :test]
+task default: [:test, :rubocop]

--- a/app.rb
+++ b/app.rb
@@ -31,6 +31,10 @@ end
 use Rack::Flash
 
 get '/' do
+  if current_user
+    @application = Application.new
+    @applications = current_user.applications
+  end
   erb :index
 end
 
@@ -85,4 +89,17 @@ post '/everypolitician-data-push' do
     UpdateViewerSinatraJob.perform_async(push)
   end
   'OK'
+end
+
+post '/applications' do
+  halt if current_user.nil?
+  @applications = current_user.applications
+  @application = Application.new(params[:application])
+  @application.user_id = current_user.id
+  if @application.valid?
+    @application.save
+    redirect to('/')
+  else
+    erb :index
+  end
 end

--- a/app.rb
+++ b/app.rb
@@ -96,6 +96,7 @@ post '/applications' do
   @applications = current_user.applications
   @application = Application.new(params[:application])
   @application.user_id = current_user.id
+  @application.secret = SecureRandom.hex(20)
   if @application.valid?
     @application.save
     redirect to('/')

--- a/app.rb
+++ b/app.rb
@@ -118,6 +118,12 @@ post '/applications/:application_id/submissions' do
   end
 end
 
+get '/applications/:application_id/submissions' do
+  content_type :json
+  @application = Application[params[:application_id]]
+  @application.submissions_dataset.to_json
+end
+
 get '/applications/:application_id/submissions/:id' do
   @application = Application[params[:application_id]]
   @submission = application.submissions_dataset[id: params[:id]]

--- a/app/jobs.rb
+++ b/app/jobs.rb
@@ -1,2 +1,3 @@
 require 'app/jobs/merge_job'
 require 'app/jobs/update_viewer_sinatra_job'
+require 'app/jobs/accept_submission_job'

--- a/app/jobs/accept_submission_job.rb
+++ b/app/jobs/accept_submission_job.rb
@@ -1,6 +1,7 @@
 require 'github'
 require 'open-uri'
 require 'github_file_updater'
+require 'csv'
 
 # Takes an approved 3rd party submission and adds it to everypolitician-data
 class AcceptSubmissionJob
@@ -30,7 +31,7 @@ class AcceptSubmissionJob
     data = JSON.parse(submission.data)
     csv << CSV::Row.new(*csv_data_for(data))
     updater = GithubFileUpdater.new(github_repository, csv_path)
-    updater.update(csv)
+    updater.update(csv.to_s)
   end
 
   def csv_from_github

--- a/app/jobs/accept_submission_job.rb
+++ b/app/jobs/accept_submission_job.rb
@@ -1,5 +1,3 @@
-require 'base64'
-require 'date'
 require 'github'
 require 'open-uri'
 require 'github_file_updater'
@@ -10,49 +8,61 @@ class AcceptSubmissionJob
   include Github
 
   attr_reader :submission
+  attr_reader :country
 
   def perform(submission_id)
     @submission = Submission[submission_id]
+    @country = get_country(submission.country)
     accept_submission
   end
+
+  private
 
   def get_country(name)
     url = 'https://github.com/everypolitician/everypolitician-data/' \
       'raw/master/countries.json'
     countries = JSON.parse(open(url).read)
-    countries.find { |c| c['name'] == name }
+    countries.find { |c| c['country'] == name }
   end
 
   def accept_submission
-    # TODO: Change me
-    github_repository = 'chrismytton/everypolitician-data'
-    country_name = submission.country.gsub(' ', '_')
-    country = get_country(country_name)
-    csv_path = File.join(
+    csv = csv_from_github
+    data = JSON.parse(submission.data)
+    csv << CSV::Row.new(*csv_data_for(data))
+    updater = GithubFileUpdater.new(github_repository, csv_path)
+    updater.update(csv)
+  end
+
+  def csv_from_github
+    csv_text = github.contents(
+      github_repository,
+      path: csv_path,
+      accept: 'application/vnd.github.v3.raw'
+    )
+    CSV.parse(csv_text, headers: true)
+  rescue Octokit::NotFound
+    # No existing CSV
+    CSV::Table.new([])
+  end
+
+  def github_repository
+    @github_repository ||= ENV.fetch('EVERYPOLITICIAN_DATA_REPO')
+  end
+
+  def csv_path
+    @csv_path ||= File.join(
       country['sources_directory'],
       "#{submission.application.name}.csv"
     )
-    begin
-      existing_csv = github.contents(
-        github_repository,
-        path: csv_path
-      )
-      csv_text = Base64.decode64(existing_csv[:content])
-      csv = CSV.parse(csv_text, headers: true)
-    rescue Octokit::NotFound
-      # No existing CSV
-      csv = CSV::Table.new([])
-    end
-    data = JSON.parse(submission.data)
+  end
+
+  def csv_data_for(data)
     headers = [:id]
     values = [submission.person_id]
     data.each do |key, value|
       headers << key
       values << value
     end
-    csv << CSV::Row.new(headers, values)
-
-    updater = GithubFileUpdater.new(github_repository, csv_path)
-    updater.update(csv)
+    [headers, values]
   end
 end

--- a/app/jobs/accept_submission_job.rb
+++ b/app/jobs/accept_submission_job.rb
@@ -1,0 +1,58 @@
+require 'base64'
+require 'date'
+require 'github'
+require 'open-uri'
+require 'github_file_updater'
+
+# Takes an approved 3rd party submission and adds it to everypolitician-data
+class AcceptSubmissionJob
+  include Sidekiq::Worker
+  include Github
+
+  attr_reader :submission
+
+  def perform(submission_id)
+    @submission = Submission[submission_id]
+    accept_submission
+  end
+
+  def get_country(name)
+    url = 'https://github.com/everypolitician/everypolitician-data/' \
+      'raw/master/countries.json'
+    countries = JSON.parse(open(url).read)
+    countries.find { |c| c['name'] == name }
+  end
+
+  def accept_submission
+    # TODO: Change me
+    github_repository = 'chrismytton/everypolitician-data'
+    country_name = submission.country.gsub(' ', '_')
+    country = get_country(country_name)
+    csv_path = File.join(
+      country['sources_directory'],
+      "#{submission.application.name}.csv"
+    )
+    begin
+      existing_csv = github.contents(
+        github_repository,
+        path: csv_path
+      )
+      csv_text = Base64.decode64(existing_csv[:content])
+      csv = CSV.parse(csv_text, headers: true)
+    rescue Octokit::NotFound
+      # No existing CSV
+      csv = CSV::Table.new([])
+    end
+    data = JSON.parse(submission.data)
+    headers = [:id]
+    values = [submission.person_id]
+    data.each do |key, value|
+      headers << key
+      values << value
+    end
+    csv << CSV::Row.new(headers, values)
+
+    updater = GithubFileUpdater.new(github_repository, csv_path)
+    updater.update(csv)
+  end
+end

--- a/app/jobs/update_viewer_sinatra_job.rb
+++ b/app/jobs/update_viewer_sinatra_job.rb
@@ -5,15 +5,20 @@ class UpdateViewerSinatraJob
   include Sidekiq::Worker
 
   attr_accessor :push
+  attr_reader :github_updater
+
+  def initialize(github_updater = GithubFileUpdater)
+    @github_updater = github_updater
+  end
 
   def perform(push)
     @push = push
+    return unless push_valid?
     countries_json_url = 'https://raw.githubusercontent.com/' \
       'everypolitician/everypolitician-data/' \
       "#{push['after']}/countries.json"
-    return unless push_valid?
     github_repository = ENV.fetch('VIEWER_SINATRA_REPO')
-    updater = GithubFileUpdater.new(github_repository, 'DATASOURCE')
+    updater = github_updater.new(github_repository, 'DATASOURCE')
     updater.update(countries_json_url)
   end
 

--- a/app/jobs/update_viewer_sinatra_job.rb
+++ b/app/jobs/update_viewer_sinatra_job.rb
@@ -1,4 +1,4 @@
-require 'datasource_update'
+require 'github_file_updater'
 
 # Update viewer-sinatra repo with new countries from push event.
 class UpdateViewerSinatraJob
@@ -13,7 +13,7 @@ class UpdateViewerSinatraJob
       "#{push['after']}/countries.json"
     return unless push_valid?
     github_repository = ENV.fetch('VIEWER_SINATRA_REPO')
-    updater = DatasourceUpdate.new(github_repository, 'DATASOURCE')
+    updater = GithubFileUpdater.new(github_repository, 'DATASOURCE')
     updater.update(countries_json_url)
   end
 

--- a/app/jobs/update_viewer_sinatra_job.rb
+++ b/app/jobs/update_viewer_sinatra_job.rb
@@ -8,7 +8,13 @@ class UpdateViewerSinatraJob
 
   def perform(push)
     @push = push
-    DatasourceUpdate.new(push['after']).update if push_valid?
+    countries_json_url = 'https://raw.githubusercontent.com/' \
+      'everypolitician/everypolitician-data/' \
+      "#{push['after']}/countries.json"
+    return unless push_valid?
+    github_repository = ENV.fetch('VIEWER_SINATRA_REPO')
+    updater = DatasourceUpdate.new(github_repository, 'DATASOURCE')
+    updater.update(countries_json_url)
   end
 
   def push_valid?

--- a/app/models.rb
+++ b/app/models.rb
@@ -1,3 +1,4 @@
 Sequel::Model.plugin :timestamps
 
 require 'app/models/user'
+require 'app/models/application'

--- a/app/models.rb
+++ b/app/models.rb
@@ -3,3 +3,4 @@ Sequel::Model.plugin :validation_helpers
 
 require 'app/models/user'
 require 'app/models/application'
+require 'app/models/submission'

--- a/app/models.rb
+++ b/app/models.rb
@@ -1,4 +1,5 @@
 Sequel::Model.plugin :timestamps
+Sequel::Model.plugin :validation_helpers
 
 require 'app/models/user'
 require 'app/models/application'

--- a/app/models.rb
+++ b/app/models.rb
@@ -1,5 +1,6 @@
 Sequel::Model.plugin :timestamps
 Sequel::Model.plugin :validation_helpers
+Sequel::Model.plugin :json_serializer
 
 require 'app/models/user'
 require 'app/models/application'

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,0 +1,2 @@
+class Application < Sequel::Model
+end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,2 +1,3 @@
 class Application < Sequel::Model
+  many_to_one :user
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,6 +1,7 @@
 # Represents a registered 3rd party application
 class Application < Sequel::Model
   many_to_one :user
+  one_to_many :submissions
   def validate
     super
     validates_presence [:name, :secret]

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,3 +1,8 @@
+# Represents a registered 3rd party application
 class Application < Sequel::Model
   many_to_one :user
+  def validate
+    super
+    validates_presence [:name, :secret]
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,4 +1,9 @@
 # Represents a submission from an external source
 class Submission < Sequel::Model
   many_to_one :application
+
+  def validate
+    super
+    validates_presence [:data, :country, :person_id, :application_id]
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,0 +1,4 @@
+# Represents a submission from an external source
+class Submission < Sequel::Model
+  many_to_one :application
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# Represents an authenticated user
 class User < Sequel::Model
   one_to_many :applications
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < Sequel::Model
+  one_to_many :applications
 end

--- a/config.ru
+++ b/config.ru
@@ -14,4 +14,8 @@ map '/sidekiq' do
   run Sidekiq::Web
 end
 
+map '/accept_submission' do
+  run AcceptSubmission
+end
+
 run Sinatra::Application

--- a/db/migrations/002_create_applications.rb
+++ b/db/migrations/002_create_applications.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  change do
+    create_table(:applications) do
+      primary_key :id
+      String :name, null: false
+      String :secret, null: false
+      String :webhook_url
+      foreign_key :user_id, :users, null: false, index: true
+      DateTime :created_at
+      DateTime :updated_at
+    end
+  end
+end

--- a/db/migrations/003_create_submissions.rb
+++ b/db/migrations/003_create_submissions.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  change do
+    create_table(:submissions) do
+      primary_key :id
+      String :data, null: false
+      String :country, null: false
+      Integer :person_id, null: false
+      foreign_key :application_id, :applications, null: false, index: true
+      DateTime :created_at
+      DateTime :updated_at
+    end
+  end
+end

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -3,6 +3,8 @@ module Github
   def github
     @github ||= Octokit::Client.new(access_token: ENV['GITHUB_ACCESS_TOKEN'])
   end
+  module_function :github
+  public :github
 
   def clone_url(uri)
     repo_clone_url = URI.parse(uri)

--- a/lib/github_file_updater.rb
+++ b/lib/github_file_updater.rb
@@ -2,7 +2,7 @@ require 'date'
 require 'github'
 
 # Update GitHub file and open pull request
-class DatasourceUpdate
+class GithubFileUpdater
   attr_reader :github_repository
   attr_reader :file_path
   attr_reader :github

--- a/lib/github_file_updater.rb
+++ b/lib/github_file_updater.rb
@@ -28,18 +28,25 @@ class GithubFileUpdater
     @file ||= github.contents(github_repository, path: file_path)
   end
 
+  def file_exists?
+    !file.nil?
+  rescue Octokit::NotFound
+    false
+  end
+
   def create_ref
     github.create_ref(github_repository, "heads/#{branch_name}", master_sha)
   end
 
   def update_contents(contents)
-    github.update_contents(
+    options = { branch: branch_name }
+    options[:sha] = file[:sha] if file_exists?
+    github.create_contents(
       github_repository,
-      file[:path],
+      file_path,
       message,
-      file[:sha],
       contents,
-      branch: branch_name
+      options
     )
   end
 
@@ -59,6 +66,6 @@ class GithubFileUpdater
   end
 
   def message
-    @message ||= "Update #{file[:name]}"
+    @message ||= "Update #{file_path}"
   end
 end

--- a/spec/github_file_updater_spec.rb
+++ b/spec/github_file_updater_spec.rb
@@ -27,15 +27,15 @@ describe GithubFileUpdater do
       [ENV['VIEWER_SINATRA_REPO'], "heads/#{subject.branch_name}", 'def456']
     )
     github.expect(
-      :update_contents,
+      :create_contents,
       true,
       [
         ENV['VIEWER_SINATRA_REPO'],
         'DATASOURCE',
         'Update DATASOURCE',
-        'abc123',
         countries_json_url,
-        branch: subject.branch_name
+        branch: subject.branch_name,
+        sha: 'abc123'
       ]
     )
     github.expect(

--- a/spec/github_file_updater_spec.rb
+++ b/spec/github_file_updater_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe DatasourceUpdate do
+describe GithubFileUpdater do
   let(:github) { Minitest::Mock.new }
   subject do
-    DatasourceUpdate.new(ENV['VIEWER_SINATRA_REPO'], 'DATASOURCE', github)
+    GithubFileUpdater.new(ENV['VIEWER_SINATRA_REPO'], 'DATASOURCE', github)
   end
   let(:countries_json_url) do
     'https://raw.githubusercontent.com/everypolitician/everypolitician-data/' \

--- a/views/index.erb
+++ b/views/index.erb
@@ -26,11 +26,6 @@
     </div>
 
     <div class="form-group">
-      <label for="application_secret">Secret</label>
-      <input type="text" id="application_secret" name="application[secret]" class="form-control">
-    </div>
-
-    <div class="form-group">
       <label for="application_webhook_url">Webhook url</label>
       <input type="url" id="application_webhook_url" name="application[webhook_url]" class="form-control">
     </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -2,6 +2,42 @@
 
   <p>Logged in as <%= current_user.name %></p>
 
+  <h2>Applications</h2>
+  <ul>
+    <% @applications.each do |application| %>
+      <li><%= application.name %></li>
+    <% end %>
+  </ul>
+
+  <% if @application.errors.any? %>
+    <p>Some errors prevented this application from being saved:</p>
+    <ul>
+    <% @application.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+    </ul>
+  <% end %>
+
+  <form method="post" action="<%= url '/applications' %>">
+    <p>Create a new application</p>
+    <div class="form-group">
+      <label for="application_name">Name</label>
+      <input type="text" id="application_name" name="application[name]" class="form-control">
+    </div>
+
+    <div class="form-group">
+      <label for="application_secret">Secret</label>
+      <input type="text" id="application_secret" name="application[secret]" class="form-control">
+    </div>
+
+    <div class="form-group">
+      <label for="application_webhook_url">Webhook url</label>
+      <input type="url" id="application_webhook_url" name="application[webhook_url]" class="form-control">
+    </div>
+
+    <input type="submit" value="Create" class="btn btn-default">
+  </form>
+
 <% else %>
 
     <p class="login-prompt">

--- a/views/new_submission.erb
+++ b/views/new_submission.erb
@@ -1,0 +1,3 @@
+<p>You have successfully submitted an update for <%= @application.name %>. It now needs to be approved before it's published.</p>
+
+<p>Person: <%= @submission.person_id %>, Twitter: <%= @submission.twitter %>.</p>


### PR DESCRIPTION
Allow 3rd party apps to be registered and submit changes to data. Then when an update is confirmed that data is pushed to everypolitican-data.

Things that still need to be done in separate tickets once this is merged:

- Webhook to notify 3rd party apps about new submissions
- Tests for the bits that aren't properly tested (`COVERAGE=1 bundle exec rake test` will generate a coverage report)
- Better application management for editing name, regenerating secret, displaying key and id etc